### PR TITLE
feat: AUR package and Makefile release targets

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,13 @@
+pkgbase = mmaid
+	pkgdesc = Terminal Mermaid diagram renderer - inline diagrams from Mermaid syntax in your terminal
+	pkgver = 0.2.0
+	pkgrel = 1
+	url = https://github.com/aaronsb/mmaid-go
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	makedepends = go>=1.23
+	source = mmaid-0.2.0.tar.gz::https://github.com/aaronsb/mmaid-go/archive/v0.2.0.tar.gz
+	sha256sums = 786b4f995bd1486cf44328ae77455aea8a63c5d95c9914656990f11f9311132f
+
+pkgname = mmaid

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 # Scratch diagram files
 /*.mmd
 termaid
+# makepkg build artifacts
+/pkg/
+/src/
+*.pkg.tar.zst
+# Cross-compiled binaries
+/dist/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: build test test-visual clean install lint vet
+.PHONY: build test test-visual clean install lint vet release aur aur-push
 
 BINARY := mmaid
 BUILD_DIR := .
+AUR_REPO_DIR ?= $(HOME)/Projects/aur/mmaid
+GITHUB_REPO := aaronsb/mmaid-go
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY) ./cmd/mmaid
@@ -28,3 +30,47 @@ clean:
 	rm -f $(BINARY)
 
 all: clean build test
+
+# --- AUR packaging ---
+
+# Detect version from latest git tag
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+
+# Update PKGBUILD with latest version and checksum, copy to AUR repo
+aur:
+	@if [ -z "$(VERSION)" ]; then echo "ERROR: No git tag found. Tag a release first."; exit 1; fi
+	@echo "Updating PKGBUILD for v$(VERSION)..."
+	@TARBALL_URL="https://github.com/$(GITHUB_REPO)/archive/v$(VERSION).tar.gz"; \
+	SHA256=$$(curl -sL "$$TARBALL_URL" | sha256sum | awk '{print $$1}'); \
+	sed -i "s/^pkgver=.*/pkgver=$(VERSION)/" PKGBUILD; \
+	sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD; \
+	sed -i "s/^sha256sums=.*/sha256sums=('$$SHA256')/" PKGBUILD; \
+	echo "SHA256: $$SHA256"
+	@echo "PKGBUILD updated."
+	@if [ ! -d "$(AUR_REPO_DIR)" ]; then \
+		echo "AUR repo not found at $(AUR_REPO_DIR), cloning..."; \
+		mkdir -p "$$(dirname "$(AUR_REPO_DIR)")"; \
+		git clone "ssh://aur@aur.archlinux.org/mmaid.git" "$(AUR_REPO_DIR)"; \
+	fi
+	@cp PKGBUILD "$(AUR_REPO_DIR)/"
+	@cd "$(AUR_REPO_DIR)" && makepkg --printsrcinfo > .SRCINFO
+	@echo "Copied PKGBUILD and generated .SRCINFO in $(AUR_REPO_DIR)"
+
+# Commit and push AUR repo
+aur-push: aur
+	@cd "$(AUR_REPO_DIR)" && \
+	git add PKGBUILD .SRCINFO && \
+	git diff --cached --quiet && echo "No changes to push." && exit 0 || true; \
+	cd "$(AUR_REPO_DIR)" && \
+	git commit -m "Update to $(VERSION)" && \
+	git push && \
+	echo "Pushed to AUR. Users can install with: yay -S mmaid"
+
+# Full release: tag + GitHub release + AUR
+release:
+ifndef VERSION
+	$(error VERSION is required. Usage: make release VERSION=x.y.z)
+endif
+	@echo "Creating GitHub release v$(VERSION)..."
+	gh release create "v$(VERSION)" --title "v$(VERSION)" --generate-notes
+	@$(MAKE) aur-push

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Aaron Bockelie <aaronsb@gmail.com>
+pkgname=mmaid
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="Terminal Mermaid diagram renderer - inline diagrams from Mermaid syntax in your terminal"
+arch=('x86_64' 'aarch64')
+url="https://github.com/aaronsb/mmaid-go"
+license=('MIT')
+depends=()
+makedepends=('go>=1.23')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/aaronsb/mmaid-go/archive/v$pkgver.tar.gz")
+sha256sums=('786b4f995bd1486cf44328ae77455aea8a63c5d95c9914656990f11f9311132f')
+
+build() {
+    cd "$srcdir/mmaid-go-$pkgver"
+    export CGO_ENABLED=0
+    go build -trimpath -ldflags="-s -w" -o "$pkgname" ./cmd/mmaid
+}
+
+package() {
+    cd "$srcdir/mmaid-go-$pkgver"
+    install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
## Summary
- PKGBUILD for AUR publication — builds from source with `go build -trimpath -ldflags="-s -w"`
- `.SRCINFO` generated and verified with `makepkg --printsrcinfo`
- Makefile targets: `make aur`, `make aur-push`, `make release VERSION=x.y.z`
- Tested locally: `makepkg -sf` builds clean with no warnings, packaged binary works

## Workflow
```bash
# Update PKGBUILD + copy to AUR repo
make aur

# Commit and push to AUR
make aur-push

# Full release (GitHub + AUR)
make release VERSION=0.3.0
```

## Test plan
- [x] `makepkg -sf` builds without warnings
- [x] Packaged binary renders diagrams correctly
- [x] `makepkg --printsrcinfo` generates valid .SRCINFO
- [x] SHA256 checksum matches v0.2.0 tarball