### PR TITLE
Publish through arch-repo instead of from here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ termaid
 /*.tar.gz
 # Cross-compiled binaries
 /dist/
+# make package dry run
+/pkgbuild-check/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-.PHONY: build test test-visual clean install lint vet dist release aur aur-push
+.PHONY: help all build test test-short test-visual clean install lint vet dist release check package version
 
 BINARY := mmaid
 BUILD_DIR := .
-AUR_REPO_DIR ?= $(HOME)/Projects/aur/mmaid
 GITHUB_REPO := aaronsb/mmaid-go
 
 build:
@@ -45,51 +44,79 @@ dist:
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-windows-amd64.exe ./cmd/mmaid
 	@echo "Built binaries in $(DIST_DIR)/"
 
-# --- AUR packaging ---
+# --- arch-repo's packaging contract ---
+#
+# https://github.com/aaronsb/arch-repo/blob/main/docs/packaging-contract.md
+#
+# arch-repo watches this repository, reads ./PKGBUILD from the default branch,
+# takes the version and checksum from the newest published release, and pushes
+# to the AUR and the [aaronsb] pacman repository. There is deliberately no aur
+# target: a second writer to one AUR ref is how a PKGBUILD and its .SRCINFO
+# drift apart.
 
-# Detect version from latest git tag
-VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+NAME    := $(shell sed -n 's/^pkgname=//p' PKGBUILD)
+SRCNAME := $(or $(shell sed -n 's/^_repo=//p' PKGBUILD),$(NAME))
 
-# Update PKGBUILD with latest version and checksum, copy to AUR repo
-aur:
-	@if [ -z "$(VERSION)" ]; then echo "ERROR: No git tag found. Tag a release first."; exit 1; fi
-	@echo "Updating PKGBUILD for v$(VERSION)..."
-	@TARBALL_URL="https://github.com/$(GITHUB_REPO)/archive/v$(VERSION).tar.gz"; \
-	SHA256=$$(curl -sL "$$TARBALL_URL" | sha256sum | awk '{print $$1}'); \
-	sed -i "s/^pkgver=.*/pkgver=$(VERSION)/" PKGBUILD; \
-	sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD; \
-	sed -i "s/^sha256sums=.*/sha256sums=('$$SHA256')/" PKGBUILD; \
-	echo "SHA256: $$SHA256"
-	@echo "PKGBUILD updated."
-	@if [ ! -d "$(AUR_REPO_DIR)" ]; then \
-		echo "AUR repo not found at $(AUR_REPO_DIR), cloning..."; \
-		mkdir -p "$$(dirname "$(AUR_REPO_DIR)")"; \
-		git clone "ssh://aur@aur.archlinux.org/mmaid.git" "$(AUR_REPO_DIR)"; \
+# This project keeps its version in the binary rather than a manifest, because
+# `mmaid --version` has to report it.
+VERSION := $(shell sed -n 's/^const version = "\(.*\)"/\1/p' cmd/mmaid/main.go)
+
+help: ## List targets
+	@grep -hE '^[a-z][a-z-]*:.*##' $(MAKEFILE_LIST) | sed 's/:.*## /\t/' | expand -t20
+
+check: version vet test-short ## Everything CI would run
+
+# PKGBUILD's pkgver is a placeholder arch-repo overwrites, so it is not one of
+# the values compared here. What has to agree is the tag about to be cut and the
+# version the binary reports. Reporting rather than failing: before a release
+# the tag is legitimately absent and after one it is legitimately present.
+version: ## Report the version this repository would release
+	@test -n "$(VERSION)" || { echo "no const version in cmd/mmaid/main.go" >&2; exit 1; }
+	@test -n "$(NAME)"    || { echo "no pkgname in PKGBUILD" >&2; exit 1; }
+	@if git rev-parse -q --verify "refs/tags/v$(VERSION)" >/dev/null; then \
+	    echo "$(NAME) $(VERSION) — v$(VERSION) is already tagged"; \
+	else \
+	    echo "$(NAME) $(VERSION) — not yet tagged; this is what the next release will be"; \
 	fi
-	@cp PKGBUILD "$(AUR_REPO_DIR)/"
-	@cd "$(AUR_REPO_DIR)" && makepkg --printsrcinfo > .SRCINFO
-	@echo "Copied PKGBUILD and generated .SRCINFO in $(AUR_REPO_DIR)"
 
-# Commit and push AUR repo
-aur-push: aur
-	@cd "$(AUR_REPO_DIR)" && \
-	git add PKGBUILD .SRCINFO && \
-	git diff --cached --quiet && echo "No changes to push." && exit 0 || true; \
-	cd "$(AUR_REPO_DIR)" && \
-	git commit -m "Update to $(VERSION)" && \
-	git push && \
-	echo "Pushed to AUR. Users can install with: yay -S mmaid"
+package: version ## Build ./PKGBUILD in a clean chroot and namcap it
+	@command -v extra-x86_64-build >/dev/null || { echo "needs devtools" >&2; exit 1; }
+	@command -v updpkgsums >/dev/null        || { echo "needs pacman-contrib" >&2; exit 1; }
+	@command -v namcap >/dev/null            || { echo "needs namcap" >&2; exit 1; }
+	rm -rf pkgbuild-check && mkdir -p pkgbuild-check
+	# The tarball the release would carry, built from HEAD and named exactly
+	# what source= resolves to, so makepkg uses it instead of reaching for the
+	# published archive — which does not exist until the tag does, and would
+	# make a pre-release dry run impossible.
+	git archive --format=tar.gz --prefix=$(SRCNAME)-$(VERSION)/ \
+	    -o pkgbuild-check/$(NAME)-$(VERSION).tar.gz HEAD
+	cp PKGBUILD $(wildcard *.install) pkgbuild-check/
+	cd pkgbuild-check && sed -i 's/^pkgver=.*/pkgver=$(VERSION)/' PKGBUILD && updpkgsums
+	cd pkgbuild-check && extra-x86_64-build
+	# namcap exits 0 whether or not it found errors, so its output decides —
+	# the same rule arch-repo's gate uses. Debug packages are excluded because
+	# every .build-id entry in one is a symlink into the main package.
+	cd pkgbuild-check && namcap PKGBUILD $$(ls ./*.pkg.tar.zst | grep -v -- '-debug-') | tee namcap.txt
+	@cd pkgbuild-check && if [ -f ../.namcap-allow ]; then \
+	    bad=$$(grep ' E: ' namcap.txt | grep -vE -f ../.namcap-allow || true); \
+	  else \
+	    bad=$$(grep ' E: ' namcap.txt || true); \
+	  fi; \
+	  if [ -n "$$bad" ]; then echo "namcap errors:"; printf '%s\n' "$$bad"; exit 1; fi; \
+	  echo "namcap: no errors"
 
-# Full release: cross-compile + GitHub release with binaries + AUR
-release: dist
+# The artifacts a release must carry. For the AUR and [aaronsb] that is nothing
+# — arch-repo reads the source tarball GitHub generates. The cross-compiled
+# binaries below are for everyone not on Arch.
+release: dist ## Cross-compile, and cut the GitHub release the packaging reads
 ifndef VERSION
-	$(error VERSION is required. Usage: make release VERSION=x.y.z)
+	$(error no version found)
 endif
-	@echo "Creating GitHub release v$(VERSION)..."
+	@test -n "$(VERSION)"
 	gh release create "v$(VERSION)" --title "v$(VERSION)" --generate-notes \
 		$(DIST_DIR)/$(BINARY)-linux-amd64 \
 		$(DIST_DIR)/$(BINARY)-linux-arm64 \
 		$(DIST_DIR)/$(BINARY)-darwin-amd64 \
 		$(DIST_DIR)/$(BINARY)-darwin-arm64 \
 		$(DIST_DIR)/$(BINARY)-windows-amd64.exe
-	@$(MAKE) aur-push
+	@echo "arch-repo picks this up on its next run; nothing else to do"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,10 @@
 # Maintainer: Aaron Bockelie <aaronsb@gmail.com>
 pkgname=mmaid
+
+# The repository is not named after the package, so the tarball extracts to
+# mmaid-go-$pkgver rather than mmaid-$pkgver. Naming it here keeps build() and
+# the Makefile's dry run reading the same value instead of both hardcoding it.
+_repo=mmaid-go
 pkgver=0.5.0
 pkgrel=1
 pkgdesc="Terminal Mermaid diagram renderer - inline diagrams from Mermaid syntax in your terminal"
@@ -12,13 +17,13 @@ source=("$pkgname-$pkgver.tar.gz::https://github.com/aaronsb/mmaid-go/archive/v$
 sha256sums=('2c33658cc7826a9686310153b80f46b82d4d55054b34e589007dd1c8dc1cdd1d')
 
 build() {
-    cd "$srcdir/mmaid-go-$pkgver"
+    cd "$srcdir/$_repo-$pkgver"
     export CGO_ENABLED=0
     go build -trimpath -ldflags="-s -w" -o "$pkgname" ./cmd/mmaid
 }
 
 package() {
-    cd "$srcdir/mmaid-go-$pkgver"
+    cd "$srcdir/$_repo-$pkgver"
     install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
     install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"


### PR DESCRIPTION
`arch-repo` watches this repository now — it reads `./PKGBUILD` from the default
branch, takes the version and checksum from the newest published release, builds
in a clean container, lints, signs, and pushes to the AUR and the `[aaronsb]`
pacman repository.

## Removed

`aur`, `aur-push`, `AUR_REPO_DIR`. Two writers to one AUR ref is how a PKGBUILD
and its `.SRCINFO` drift apart — and the sed-the-checksum-in dance those targets
performed is the circularity arch-repo removes by taking the recipe from the
branch and the hash from the release.

`release` keeps everything else. The cross-compiled darwin and windows binaries
are for people not on Arch and are what the tag genuinely carries; only the
`aur-push` call at the end is gone.

## Added

| Target | What it does |
|---|---|
| `check` | `go vet` + short tests, plus reporting the version this repo would release |
| `package` | builds `./PKGBUILD` in a clean chroot and **fails on a namcap error** |
| `version` | reports the version and whether its tag exists |
| `help` | lists them |

`package` is the one that earns its place. Two details make it work:

- **The tarball comes from `git archive` against `HEAD`**, named exactly what
  `source=` resolves to, so makepkg uses it rather than fetching
  `archive/v$pkgver.tar.gz` — which GitHub does not generate until the tag
  exists. A dry run that needs the release to have already happened is not a dry
  run.
- **namcap's output decides, not its exit code.** It exits 0 whether or not it
  found errors. Same rule arch-repo's gate uses: errors fail, warnings do not.

## The recipe now names the repository

`pkgname` is `mmaid` but the tarball extracts to `mmaid-go-$pkgver`, and
`build()` had that hardcoded — so anything else needing the prefix had to
hardcode it again and agree by luck. `_repo=mmaid-go` says it once, and both
`build()` and the dry run read it.

## Verified

Whole target run against an untagged `0.5.1`:

```
mmaid 0.5.1 — not yet tagged; this is what the next release will be
==> Retrieving sources...
  -> Found mmaid-0.5.1.tar.gz
mmaid W: ELF file ('usr/bin/mmaid') lacks FULL RELRO, check LDFLAGS.
mmaid W: ELF file ('usr/bin/mmaid') lacks PIE.
namcap: no errors
```

## Contract

- [the contract](https://github.com/aaronsb/arch-repo/blob/main/docs/packaging-contract.md)
- [a worked example](https://github.com/aaronsb/arch-repo/tree/main/docs/example)
- [ADR-100](https://github.com/aaronsb/arch-repo/blob/main/docs/architecture/packaging/ADR-100-one-packaging-contract-for-every-repository-arch-repo-publishes.md)